### PR TITLE
chore: Upgrade dependencies and package version for `hyprland`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hyprland"
 version = "0.3.1"
-source = "git+https://github.com/hyprland-community/hyprland-rs#b8311e7b03c81ac76ec94ae264425fa0b467ef6f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d341e36a776cd092622daf2439a484247f3dc7d25eab7b286cc88ac85120d3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -372,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "hyprland-autoname-workspaces"
-version = "0.3.7"
+version = "0.3.9"
 dependencies = [
  "clap",
  "hyprland",
@@ -386,8 +387,9 @@ dependencies = [
 
 [[package]]
 name = "hyprland-macros"
-version = "0.1.0"
-source = "git+https://github.com/hyprland-community/hyprland-rs#b8311e7b03c81ac76ec94ae264425fa0b467ef6f"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0088021091c08e29e9d1f735142ab811bd4d4d7f82fd4d4673407cb96fffb062"
 dependencies = [
  "quote",
  "syn 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyprland-autoname-workspaces"
 authors = ["Cyril Levis", "Maxim Baz"]
-version = "0.3.7"
+version = "0.3.9"
 edition = "2021"
 categories = ["gui"]
 keywords = ["linux", "desktop-application", "hyprland","waybar","wayland"]
@@ -13,7 +13,7 @@ repository = "https://github.com/cyrinux/hyprland-autoname-workspaces"
 
 [dependencies]
 clap = { version = "4.1.1", features = ["derive"] }
-hyprland = { git = "https://github.com/hyprland-community/hyprland-rs" }
+hyprland = "0.3.1"
 signal-hook = "0.3.14"
 toml = { version = "0.5.10", features = ["indexmap", "preserve_order"] }
 xdg = "2.4.1"


### PR DESCRIPTION
- Upgrade `hyprland` dependency to version `0.3.1`
- Upgrade package version to `0.3.9`

