### PR TITLE
fix: I can't find how to send a slash to Rename dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,8 +329,6 @@ dependencies = [
 [[package]]
 name = "hyprland"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2166a21b9f0018d522bfd25debccdb16af8d2100aee63f842f9da37256129571"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -367,8 +365,6 @@ dependencies = [
 [[package]]
 name = "hyprland-macros"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de65550b4ec230167654f367b6ec02795acf2cfd9692f05bedb10ff09e46a6e"
 dependencies = [
  "quote",
  "syn 2.0.15",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,7 +67,7 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
         .icons
         .iter()
         .filter_map(|(class, icon)| {
-            regex_with_error_logging(class).map(|re| (re, icon.to_string()))
+            regex_with_error_logging(class).map(|re| (re, icon.to_string().replace("/", "∕")))
         })
         .collect();
 
@@ -81,7 +81,8 @@ pub fn read_config_file(cfg_path: &PathBuf) -> Result<ConfigFile, Box<dyn Error>
                     title_icon
                         .iter()
                         .filter_map(|(title, icon)| {
-                            regex_with_error_logging(title).map(|re| (re, icon.to_string()))
+                            regex_with_error_logging(title)
+                                .map(|re| (re, icon.to_string().replace("/", "∕")))
                         })
                         .collect(),
                 )


### PR DESCRIPTION
lets replace slash by an unicode slash for the moment to prevent crash.

https://www.compart.com/en/unicode/U+2215


But we can't use `<span color="orange">firefox</span>` waybar feature until we are not able to send slash.